### PR TITLE
removes console.log from amOutsideAngularApp()

### DIFF
--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -164,7 +164,6 @@ class Protractor extends SeleniumWebdriver {
    */
   amOutsideAngularApp() {
      if (this.browser.driver && this.insideAngular) {
-       console.log(this.browser.driver);
        this.browser = this.browser.driver;
        this.insideAngular = false;
      }


### PR DESCRIPTION
Removing the console.log which is adding the Webdriver Object to the test report.

Solves issue #181
